### PR TITLE
Add frictionlessRequests parameter to FB.init({})

### DIFF
--- a/grails-app/taglib/grails/plugin/facebooksdk/FacebookJSTagLib.groovy
+++ b/grails-app/taglib/grails/plugin/facebooksdk/FacebookJSTagLib.groovy
@@ -24,6 +24,7 @@ class FacebookJSTagLib {
 	* @attr locale (Default to server locale)
 	* @attr status (Default to false)
 	* @attr	xfbml (Default to false)
+	* @attr frictionlessRequests (Default to false)
 	*/
 	def initJS = { attrs, body ->
 		if (!attrs.containsKey("cookie")) attrs.cookie = true

--- a/grails-app/views/facebook-sdk/_init-js.gsp
+++ b/grails-app/views/facebook-sdk/_init-js.gsp
@@ -7,7 +7,8 @@
 			cookie: <g:if test="${cookie}">true</g:if><g:else>false</g:else>, // enable cookies to allow the server to access the session
 			oauth: true, // enables OAuth 2.0
 			status: <g:if test="${status}">true</g:if><g:else>false</g:else>, // check login status
-			xfbml: <g:if test="${xfbml}">true</g:if><g:else>false</g:else> // parse XFBML
+			xfbml: <g:if test="${xfbml}">true</g:if><g:else>false</g:else>, // parse XFBML
+			frictionlessRequests: <g:if test="${frictionlessRequests}">true</g:if><g:else>false</g:else> // to enable frictionless requests
 		});
 		
 		<g:if test="${autoGrow}">


### PR DESCRIPTION
Add frictionlessRequests parameter to enable frictionless requests in FB.init({}) ; default set to false.
