### PR TITLE
Added feature 'customSelector' to modify the jQuery-selector name. Just ...

### DIFF
--- a/grails-app/views/tags/_add-to-page-link.gsp
+++ b/grails-app/views/tags/_add-to-page-link.gsp
@@ -1,7 +1,7 @@
 <g:if test="${includeScript}">
     <script type="text/javascript">
-        $(function() {
-            $('a.fb-sdk-add-to-page-link').click(function() {
+        ${customSelector ?: '$'}(function() {
+            ${customSelector ?: '$'}('a.fb-sdk-add-to-page-link').click(function() {
                 var link = $(this);
                 var options = {
                     method: 'pagetab'

--- a/grails-app/views/tags/_init-js.gsp
+++ b/grails-app/views/tags/_init-js.gsp
@@ -3,9 +3,9 @@
     <div id="fb-root"></div>
     <script type="text/javascript">
         // Disable all fb sdk links until FB JS SDK is initialized
-        $(function() {
+        ${customSelector ?: '$'}(function() {
             if (!window.FB) {
-                $('.fb-sdk-link').attr('disabled', 'disabled').addClass('disabled');
+                ${customSelector ?: '$'}('.fb-sdk-link').attr('disabled', 'disabled').addClass('disabled');
             }
         });
 
@@ -19,7 +19,7 @@
                 xfbml: <g:if test="${xfbml}">true</g:if><g:else>false</g:else>, // parse XFBML
                 frictionlessRequests: <g:if test="${frictionlessRequests}">true</g:if><g:else>false</g:else> // to enable frictionless requests
             });
-            $('.fb-sdk-link').removeAttr('disabled').removeClass('disabled');
+            ${customSelector ?: '$'}('.fb-sdk-link').removeAttr('disabled').removeClass('disabled');
 
             <g:if test="${autoGrow}">
                 FB.Canvas.setAutoGrow();

--- a/grails-app/views/tags/_invite-link.gsp
+++ b/grails-app/views/tags/_invite-link.gsp
@@ -1,8 +1,8 @@
 <%@ page import="grails.converters.JSON" %>
 <g:if test="${includeScript}">
     <script type="text/javascript">
-        $(function() {
-            $('a.fb-sdk-invite-link').click(function() {
+        ${customSelector ?: '$'}(function() {
+            ${customSelector ?: '$'}('a.fb-sdk-invite-link').click(function() {
                 var link = $(this);
                 var options = {
                     method: 'apprequests',

--- a/grails-app/views/tags/_login-link.gsp
+++ b/grails-app/views/tags/_login-link.gsp
@@ -1,7 +1,7 @@
 <g:if test="${includeScript}">
     <script type="text/javascript">
-        $(function() {
-            $('a.fb-sdk-login-link').click(function(event) {
+        ${customSelector ?: '$'}(function() {
+            ${customSelector ?: '$'}('a.fb-sdk-login-link').click(function(event) {
                 var link = $(this);
                 link.attr('disabled', 'disabled');
                 FB.login(function(response) {

--- a/grails-app/views/tags/_logout-link.gsp
+++ b/grails-app/views/tags/_logout-link.gsp
@@ -1,7 +1,7 @@
 <g:if test="${includeScript}">
     <script type="text/javascript">
-        $(function() {
-            $('a.fb-sdk-logout-link').click(function() {
+        ${customSelector ?: '$'}(function() {
+            ${customSelector ?: '$'}('a.fb-sdk-logout-link').click(function() {
                 var link = $(this);
                 link.attr('disabled', 'disabled');
                 FB.getLoginStatus(function(response) {

--- a/grails-app/views/tags/_publish-link.gsp
+++ b/grails-app/views/tags/_publish-link.gsp
@@ -1,7 +1,7 @@
 <g:if test="${includeScript}">
     <script type="text/javascript">
-        $(function() {
-            $('a.fb-sdk-publish-link').click(function() {
+        ${customSelector ?: '$'}(function() {
+            ${customSelector ?: '$'}('a.fb-sdk-publish-link').click(function() {
                 var link = $(this);
                 var options = {
                     method: 'feed'

--- a/grails-app/views/tags/_send-link.gsp
+++ b/grails-app/views/tags/_send-link.gsp
@@ -1,7 +1,7 @@
 <g:if test="${includeScript}">
     <script type="text/javascript">
-        $(function() {
-            $('a.fb-sdk-send-link').click(function() {
+        ${customSelector ?: '$'}(function() {
+            ${customSelector ?: '$'}('a.fb-sdk-send-link').click(function() {
                 var link = $(this);
                 var options = {
                     method: 'send',


### PR DESCRIPTION
...use customSelector='jQuery' attribute in your taglib.

For example:

```
<facebook:initJS customSelector="jQuery" appId="${facebookContext.app.id}" />
```

This will render the javascript with jQuery(...) instead of $(...). 
Defaults to $, if nothing is given.
