### PR TITLE
Run task 'findMainClass' after compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,3 +77,6 @@ grailsPublish {
     portalUser = ""
     portalPassword = ""
 }
+
+findMainClass.dependsOn compileJava
+findMainClass.dependsOn compileGroovy


### PR DESCRIPTION
Hello

This commit adds two missing dependencies for the task 'findMainClass'.
Specifically, this task depends on `compileJava` and `compileGroovy` so that it would be able to find the main class file.

This build can fail, if gradle processes `findMainClass` in the erroneous order. The error I get is:

```
> Task :findMainClass FAILED
Caching disabled for task ':findMainClass' because:
  Build cache is disabled
Task ':findMainClass' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:findMainClass (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.041 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':findMainClass'.
> Could not find Application main class. Please set 'springBoot.mainClass'.
```