### PR TITLE
[Fix] Inject logger in FacebookJSTagLib

### DIFF
--- a/grails-app/taglib/FacebookJSTagLib.groovy
+++ b/grails-app/taglib/FacebookJSTagLib.groovy
@@ -1,8 +1,10 @@
 import grails.plugin.facebooksdk.FacebookLocalization
 import grails.core.GrailsApplication
 import grails.web.mapping.LinkGenerator
+import groovy.util.logging.Slf4j
 import org.springframework.web.servlet.support.RequestContextUtils
 
+@Slf4j
 class FacebookJSTagLib {
 
     static final String TYPE_LARGE = 'large'


### PR DESCRIPTION
It looks like logger is not injected automatically in Grails4 tag libs.