### PR TITLE
Ugprade/restfb 2022.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     provided "org.grails:grails-plugin-domain-class"
 
     // Latest RestFB lib
-    compile 'com.restfb:restfb:3.20.0'
+    compile 'com.restfb:restfb:2022.7.0'
 
     // Tests
     testCompile 'org.grails:grails-web-testing-support:2.0.0'


### PR DESCRIPTION
Everything is in the title. This is needed to upgrade Facebook Marketing API version to v14.